### PR TITLE
Hackers news don't have www in domain

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,7 +18,7 @@
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="padding:2px">
               <tr>
                 <td style="width:18px;padding-right:4px">
-                  <a href="http://www.news.ycombinator.com">
+                  <a href="http://news.ycombinator.com">
                     <img src="{{ url_for('static', filename='images/y18.gif') }}" width="18" height="18" style="border:1px #ffffff solid;">
                   </a>
                 </td>


### PR DESCRIPTION
There is no www for Hacker news. It's news.ycombinator.com
